### PR TITLE
use heatStatus name field rather than raw byte value for wider compat

### DIFF
--- a/custom_components/njspc_ha/climate.py
+++ b/custom_components/njspc_ha/climate.py
@@ -14,14 +14,15 @@ from .const import DOMAIN, EVENT_AVAILABILITY, EVENT_BODY
 
 NJSPC_HVAC_ACTION_TO_HASS = {
     # Map to None if we do not know how to represent.
-    0: HVACAction.OFF,
-    1: HVACAction.HEATING,
-    2: HVACAction.HEATING,
-    3: HVACAction.COOLING,
-    4: HVACAction.HEATING,
-    6: HVACAction.HEATING,
-    8: HVACAction.COOLING,
-    128: HVACAction.OFF,
+    'off':      HVACAction.OFF,
+    'heater':   HVACAction.HEATING,
+    'solar':    HVACAction.HEATING,
+    'hpheat':   HVACAction.HEATING,
+    'hybheat':  HVACAction.HEATING,
+    'mtheat':   HVACAction.HEATING,
+    'cooling':  HVACAction.COOLING,
+    'hpcool':   HVACAction.COOLING,
+    'cooldown': HVACAction.OFF,
 }
 
 
@@ -182,7 +183,7 @@ class Climate(CoordinatorEntity, ClimateEntity):
     @property
     def hvac_action(self) -> HVACAction:
         try:
-            return NJSPC_HVAC_ACTION_TO_HASS[self._body["heatStatus"]["val"]]
+            return NJSPC_HVAC_ACTION_TO_HASS[self._body["heatStatus"]["name"]]
         except:
             return HVACAction.OFF
 


### PR DESCRIPTION
Fixes #1 for my EasyTouch 8 but should also work for all currently supported boards in nodejs-poolController

![Screenshot from 2022-09-13 14-47-48](https://user-images.githubusercontent.com/46170/190022938-8e9254b8-3bf7-473e-b8fa-65cf7e0dbeb1.png)

:arrow_down: 

![Screenshot from 2022-09-13 15-47-40](https://user-images.githubusercontent.com/46170/190023010-074fa751-e7a8-4767-8d94-ad4f7ff85fb0.png)
