### PR TITLE
Additional Checks for orphan Chem Controllers

### DIFF
--- a/custom_components/njspc_ha/sensor.py
+++ b/custom_components/njspc_ha/sensor.py
@@ -132,74 +132,80 @@ async def async_setup_entry(
                 )
             )
     for chem_controller in config["chemControllers"]:
-        if "ph" in chem_controller:
-            chemical = chem_controller["ph"]
-            if chemical["enabled"] is True:
-                new_devices.append(
-                    ChemistryDosingStatus(
-                        coordinator=coordinator,
-                        chem_controller=chem_controller,
-                        chemical=chemical,
-                    )
-                )
-                new_devices.append(
-                    ChemistrySensor(
-                        coordinator=coordinator,
-                        chem_controller=chem_controller,
-                        chemical=chemical,
-                    )
-                )
-                new_devices.append(
-                    ChemistryDemandSensor(
-                        coordinator=coordinator,
-                        chem_controller=chem_controller,
-                        chemical=chemical,
-                    )
-                )
-                if "tank" in chemical:
+        if (
+            "name" in chem_controller
+            and "type" in chem_controller
+            and "name" in chem_controller["type"]
+            and chem_controller["type"]["name"] != "none"
+        ):
+            if "ph" in chem_controller:
+                chemical = chem_controller["ph"]
+                if chemical["enabled"] is True:
                     new_devices.append(
-                        ChemistryTankLevel(
+                        ChemistryDosingStatus(
                             coordinator=coordinator,
                             chem_controller=chem_controller,
                             chemical=chemical,
                         )
                     )
+                    new_devices.append(
+                        ChemistrySensor(
+                            coordinator=coordinator,
+                            chem_controller=chem_controller,
+                            chemical=chemical,
+                        )
+                    )
+                    new_devices.append(
+                        ChemistryDemandSensor(
+                            coordinator=coordinator,
+                            chem_controller=chem_controller,
+                            chemical=chemical,
+                        )
+                    )
+                    if "tank" in chemical:
+                        new_devices.append(
+                            ChemistryTankLevel(
+                                coordinator=coordinator,
+                                chem_controller=chem_controller,
+                                chemical=chemical,
+                            )
+                        )
 
-        if "orp" in chem_controller:
-            chemical = chem_controller["orp"]
-            if chemical["enabled"] is True:
-                new_devices.append(
-                    ChemistryDosingStatus(
-                        coordinator=coordinator,
-                        chem_controller=chem_controller,
-                        chemical=chemical,
-                    )
-                )
-                new_devices.append(
-                    ChemistrySensor(
-                        coordinator=coordinator,
-                        chem_controller=chem_controller,
-                        chemical=chem_controller["orp"],
-                    )
-                )
-                new_devices.append(
-                    ChemistryDemandSensor(
-                        coordinator=coordinator,
-                        chem_controller=chem_controller,
-                        chemical=chemical,
-                    )
-                )
-                if (
-                    "tank" in chemical
-                    and chemical["doserType"]["name"] != "chlorinator"
-                ):
+            if "orp" in chem_controller:
+                chemical = chem_controller["orp"]
+                if chemical["enabled"] is True:
                     new_devices.append(
-                        ChemistryTankLevel(
+                        ChemistryDosingStatus(
                             coordinator=coordinator,
                             chem_controller=chem_controller,
                             chemical=chemical,
                         )
                     )
+                    new_devices.append(
+                        ChemistrySensor(
+                            coordinator=coordinator,
+                            chem_controller=chem_controller,
+                            chemical=chem_controller["orp"],
+                        )
+                    )
+                    new_devices.append(
+                        ChemistryDemandSensor(
+                            coordinator=coordinator,
+                            chem_controller=chem_controller,
+                            chemical=chemical,
+                        )
+                    )
+                    if (
+                        "tank" in chemical
+                        and chemical["doserType"]["name"] != "chlorinator"
+                    ):
+                        new_devices.append(
+                            ChemistryTankLevel(
+                                coordinator=coordinator,
+                                chem_controller=chem_controller,
+                                chemical=chemical,
+                            )
+                        )
     for pool_filter in config["filters"]:
         new_devices.append(
             FilterPressureSensor(coordinator=coordinator, pool_filter=pool_filter)


### PR DESCRIPTION
EasyTouch can indicate that IntelliChem is installed on the pool but if it is not it will not respond to the configuration.  This creates a chemistry controller in njsPC that does not have a name or a type.  This code simply ignores chemistry controllers like this.