### PR TITLE
Fix compatibility with Home Assistant 2026.2+

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@ Add the respository URL as a custom [repository integration](https://hacs.xyz/do
 Copy the njspc_ha folder from this repo to config/custom_components (create custom_components folder if it doesn't exist already)
 
 ## Setup
-Once njsPC-HA is installed, you can set it up by adding it as an integration.  The integration should automatically find the instance of nodejs-poolcontroller for you.  It it doesn't, it'll prompt you to enter the IP address and port (default 4200).
+Once njsPC-HA is installed, you can set it up by adding it as an integration.  The integration should automatically find the instance of nodejs-poolcontroller for you.  If it doesn't, it'll prompt you to enter the IP address and port (default 4200).
+
+> **Docker users:** If both Home Assistant and nodejs-poolController run in Docker on the same host, SSDP auto-discovery may find multiple instances — one for each Docker network the njsPC container is attached to. Keep the entry that uses the container's **direct IP on its own bridge network** (e.g. `172.26.0.x`) and delete any duplicates discovered via Docker's default bridge gateway (`172.17.0.1`). The default-bridge entry often produces incomplete device lists. You can find the correct container IP in Portainer under the njsPC stack's network details.
+>
+> When entering the host manually, provide just the IP address (e.g. `192.168.1.100`) — do **not** include `http://`.
 
 
 # Data

--- a/custom_components/njspc_ha/config_flow.py
+++ b/custom_components/njspc_ha/config_flow.py
@@ -7,11 +7,12 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import aiohttp_client
-from homeassistant.components import zeroconf, ssdp
+from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from urllib.parse import urlparse
 
 
@@ -34,8 +35,16 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
 
     Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
     """
+    host = data[CONF_HOST].strip()
+    for prefix in ("https://", "http://"):
+        if host.lower().startswith(prefix):
+            host = host[len(prefix):]
+            break
+    host = host.rstrip("/")
+    data[CONF_HOST] = host
+
     session = aiohttp_client.async_get_clientsession(hass)
-    async with session.get(f'http://{data["host"]}:{data["port"]}/state/all') as resp:
+    async with session.get(f'http://{host}:{data["port"]}/state/all') as resp:
         if resp.status == 200:
             pass
         else:
@@ -59,7 +68,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle the initial step."""
         if user_input is None:
             return self.async_show_form(
@@ -86,8 +95,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
     async def async_step_zeroconf(
-        self, discovery_info: zeroconf.ZeroconfServiceInfo
-    ) -> FlowResult:
+        self, discovery_info: ZeroconfServiceInfo
+    ) -> ConfigFlowResult:
         """Handle zeroconf discovery."""
         self.zero_conf = discovery_info
         self.server_id = (
@@ -111,7 +120,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_zeroconf_confirm(
         self, user_input: dict[str, Any] = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle a flow initiated by zeroconf."""
         if user_input is not None:
             data = {
@@ -128,7 +137,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             },
         )
 
-    async def async_step_ssdp(self, discovery_info: ssdp.SsdpServiceInfo) -> FlowResult:
+    async def async_step_ssdp(self, discovery_info: SsdpServiceInfo) -> ConfigFlowResult:
         """Handle a flow initialized by SSDP discovery."""
         self.host = urlparse(discovery_info.ssdp_location).hostname
         self.port = urlparse(discovery_info.ssdp_location).port
@@ -136,7 +145,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(self.server_id)
         self._abort_if_unique_id_configured()
         self.controller_name = discovery_info.upnp.get(
-            ssdp.ATTR_UPNP_FRIENDLY_NAME, self.host
+            "friendlyName", self.host
         )
         self.context.update(
             {
@@ -151,7 +160,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_ssdp_confirm(
         self, user_input: dict[str, Any] = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle a flow initiated by zeroconf."""
         if user_input is not None:
             data = {


### PR DESCRIPTION
## Summary

- **Fix SSDP auto-discovery crash**: Replace removed `ssdp.ATTR_UPNP_FRIENDLY_NAME` constant with the literal UPnP key `"friendlyName"` — this constant was removed in HA 2026.2 ([developer blog post](https://developers.home-assistant.io/blog/2025/01/15/service-info))
- **Update deprecated imports**: Migrate `SsdpServiceInfo` and `ZeroconfServiceInfo` from `homeassistant.components` to `homeassistant.helpers.service_info` and replace deprecated `FlowResult` with `ConfigFlowResult`
- **Fix DNS error on manual config**: Strip `http://` / `https://` prefixes from user-entered host input to prevent double-scheme URLs (e.g. `http://http://192.168.1.1:4200/...`) that cause `ClientConnectorDNSError`

## Errors Fixed

```
AttributeError: module 'homeassistant.components.ssdp' has no attribute 'ATTR_UPNP_FRIENDLY_NAME'
```

```
aiohttp.client_exceptions.ClientConnectorDNSError: Cannot connect to host http:80 ssl:default [Domain name not found]
```

## Test plan

- [ ] Verify SSDP auto-discovery works (njsPC advertises itself, HA picks it up)
- [ ] Verify Zeroconf auto-discovery works
- [ ] Verify manual config flow with bare IP (e.g. `192.168.1.100`)
- [ ] Verify manual config flow with `http://` prefixed host (e.g. `http://192.168.1.100`)
- [ ] Verify integration loads without import errors on HA 2026.2+


Made with [Cursor](https://cursor.com)